### PR TITLE
Set minimal flutter version to 1.20

### DIFF
--- a/packages/platform_maps_flutter_apple/pubspec.yaml
+++ b/packages/platform_maps_flutter_apple/pubspec.yaml
@@ -7,7 +7,7 @@ issue_tracker: https://github.com/albert-heijn-technology/platform_maps_flutter/
 
 environment:
   sdk: '>=3.2.4 <4.0.0'
-  flutter: ">=1.17.0"
+  flutter: ">=1.20.0"
 
 flutter:
   plugin:

--- a/packages/platform_maps_flutter_google_android/pubspec.yaml
+++ b/packages/platform_maps_flutter_google_android/pubspec.yaml
@@ -7,7 +7,7 @@ issue_tracker: https://github.com/albert-heijn-technology/platform_maps_flutter/
 
 environment:
   sdk: '>=3.2.4 <4.0.0'
-  flutter: ">=1.17.0"
+  flutter: ">=1.20.0"
 
 flutter:
   plugin:


### PR DESCRIPTION
Probably we can set the minimal flutter version higher, but during publishing I got the following error:
```sh
pubspec.yaml allows Flutter SDK version prior to 1.20.0, which does not support having no `ios/` folder.
Please consider increasing the Flutter SDK requirement to ^1.20.0 or higher (environment.sdk.flutter) or create an `ios/` folder.

See https://flutter.dev/docs/development/packages-and-plugins/developing-packages#plugin
```

So with Flutter version set to 1.20 I could publish all packages.

## Pre-launch Checklist

- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making if a test is possible.
- [x] All existing and new tests are passing.